### PR TITLE
Increasing timeout for HAproxy so that connections for binary builds …

### DIFF
--- a/utility.fcc
+++ b/utility.fcc
@@ -117,9 +117,9 @@ storage:
               maxconn 256
           defaults
                   log global
-                  timeout connect 10s
-                  timeout client 30s
-                  timeout server 30s
+                  timeout connect 30s
+                  timeout client 600s
+                  timeout server 600s
                   mode tcp
           backend bootstrap_masters_22623
                   mode tcp


### PR DESCRIPTION
…and following pod logs don't get dropped.